### PR TITLE
Add support for 256color xterm codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ fmt.Println(colorstring.Color("[blue]Hello [red]World!"))
 
 Additionally, the `Colorize` struct can be used to set options such as
 custom colors, color disabling, etc.
+
+## 256 color terminal support
+
+Many modern terminals support 256 colors, so this library offers this with two special kinds of colors:
+
+* `[rgb]` where each letter is a number 0 to 5; 0 being darkest and 5 being brightest.
+* `[grayN]` where N is a number 0 to 15; 0 being darkest (black) and 15 being brightest.
+* Background colors are also supported like the rest of the library `[_rgb_]`
+  would be background color for that rgb level.

--- a/colorstring.go
+++ b/colorstring.go
@@ -153,6 +153,28 @@ func init() {
 		"reset_bold": "21",
 	}
 
+	// 256 color support.
+	// First, the 216 color-cube colors.
+	for r := 0; r < 6; r += 1 {
+		for g := 0; g < 6; g += 1 {
+			for b := 0; b < 6; b += 1 {
+				code := (r + g*6 + b*6*6) + 16
+				// Foreground
+				DefaultColors[fmt.Sprintf("%d%d%d", r, g, b)] = fmt.Sprintf("38;5;%d", code)
+				// Background
+				DefaultColors[fmt.Sprintf("_%d%d%d_", r, g, b)] = fmt.Sprintf("48;5;%d", code)
+			}
+		}
+	}
+
+	// Grayscale
+	for g := 0; g < 16; g += 1 {
+		// Foreground
+		DefaultColors[fmt.Sprintf("gray%d", g)] = fmt.Sprintf("38;5;%d", g+232)
+		// Background
+		DefaultColors[fmt.Sprintf("_gray%d_", g)] = fmt.Sprintf("48;5;%d", g+232)
+	}
+
 	def = Colorize{
 		Colors: DefaultColors,
 		Reset:  true,

--- a/colorstring_test.go
+++ b/colorstring_test.go
@@ -27,6 +27,7 @@ func TestColor(t *testing.T) {
 			Input:  "foo[what]foo",
 			Output: "foo[what]foo",
 		},
+
 		{
 			Input:  "foo[_blue_]foo",
 			Output: "foo\033[44mfoo\033[0m",
@@ -39,9 +40,20 @@ func TestColor(t *testing.T) {
 			Input:  "[blue]foo[bold]bar",
 			Output: "\033[34mfoo\033[1mbar\033[0m",
 		},
+
 		{
 			Input:  "[underline]foo[reset]bar",
 			Output: "\033[4mfoo\033[0mbar\033[0m",
+		},
+
+		{
+			Input:  "foo[333]foo",
+			Output: "foo\033[38;5;145mfoo\033[0m",
+		},
+
+		{
+			Input:  "foo[gray3]foo",
+			Output: "foo\033[38;5;235mfoo\033[0m",
 		},
 	}
 


### PR DESCRIPTION
- 216-color RGB cube is supported as 'rgb' with range 0-5 for each color
- 16-color Grayscale is supported as 'grayN' where N is 0-15
