### PR TITLE
Don't print reset twice

### DIFF
--- a/colorstring.go
+++ b/colorstring.go
@@ -67,8 +67,13 @@ func (c *Colorize) Color(v string) string {
 		m = nm
 
 		var replace string
-		if code, ok := c.Colors[v[m[0]+1:m[1]-1]]; ok {
-			colored = true
+		color := v[m[0]+1 : m[1]-1]
+		if code, ok := c.Colors[color]; ok {
+			if color == "reset" {
+				colored = false
+			} else {
+				colored = true
+			}
 
 			if !c.Disable {
 				replace = fmt.Sprintf("\033[%sm", code)

--- a/colorstring_test.go
+++ b/colorstring_test.go
@@ -41,7 +41,7 @@ func TestColor(t *testing.T) {
 		},
 		{
 			Input:  "[underline]foo[reset]bar",
-			Output: "\033[4mfoo\033[0mbar\033[0m",
+			Output: "\033[4mfoo\033[0mbar",
 		},
 	}
 


### PR DESCRIPTION
Currently colorstring resets the color even if it is already reset.
I use colorstring to test a colored string, and I want to test a string without an unnecessary reset.
