### PR TITLE
fmt wrapper convenience methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For usage and examples see the [Godoc](http://godoc.org/github.com/mitchellh/col
 Usage is easy enough:
 
 ```go
-fmt.Println(colorstring.Color("[blue]Hello [red]World!"))
+colorstring.Println("[blue]Hello [red]World!")
 ```
 
 Additionally, the `Colorize` struct can be used to set options such as

--- a/colorstring.go
+++ b/colorstring.go
@@ -161,6 +161,29 @@ func init() {
 var def Colorize
 var parseRe = regexp.MustCompile(`(?i)\[[a-z0-9_-]+\]`)
 
+// Print is a convenience wrapper for fmt.Print with support for color codes.
+//
+// Print formats using the default formats for its operands and writes to
+// standard output with support for color codes. Spaces are added between
+// operands when neither is a string. It returns the number of bytes written
+// and any write error encountered.
+func Print(a string) (n int, err error) {
+	return fmt.Print(Color(a))
+}
+
+// Println is a convenience wrapper for fmt.Println with support for color
+// codes.
+//
+// Println formats using the default formats for its operands and writes to
+// standard output with support for color codes. Spaces are always added
+// between operands and a newline is appended. It returns the number of bytes
+// written and any write error encountered.
+func Println(a string) (n int, err error) {
+	return fmt.Println(Color(a))
+}
+
+// Printf is a convenience wrapper for fmt.Printf with support for color codes.
+//
 // Printf formats according to a format specifier and writes to standard output
 // with support for color codes. It returns the number of bytes written and any
 // write error encountered.
@@ -168,6 +191,30 @@ func Printf(format string, a ...interface{}) (n int, err error) {
 	return fmt.Printf(Color(format), a...)
 }
 
+// Fprint is a convenience wrapper for fmt.Fprint with support for color codes.
+//
+// Fprint formats using the default formats for its operands and writes to w
+// with support for color codes. Spaces are added between operands when neither
+// is a string. It returns the number of bytes written and any write error
+// encountered.
+func Fprint(w io.Writer, a string) (n int, err error) {
+	return fmt.Fprint(w, Color(a))
+}
+
+// Fprintln is a convenience wrapper for fmt.Fprintln with support for color
+// codes.
+//
+// Fprintln formats using the default formats for its operands and writes to w
+// with support for color codes. Spaces are always added between operands and a
+// newline is appended. It returns the number of bytes written and any write
+// error encountered.
+func Fprintln(w io.Writer, a string) (n int, err error) {
+	return fmt.Fprintln(w, Color(a))
+}
+
+// Fprintf is a convenience wrapper for fmt.Fprintf with support for color
+// codes.
+//
 // Fprintf formats according to a format specifier and writes to w with support
 // for color codes. It returns the number of bytes written and any write error
 // encountered.

--- a/colorstring.go
+++ b/colorstring.go
@@ -5,6 +5,7 @@ package colorstring
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"regexp"
 )
 
@@ -159,3 +160,17 @@ func init() {
 
 var def Colorize
 var parseRe = regexp.MustCompile(`(?i)\[[a-z0-9_-]+\]`)
+
+// Printf formats according to a format specifier and writes to standard output
+// with support for color codes. It returns the number of bytes written and any
+// write error encountered.
+func Printf(format string, a ...interface{}) (n int, err error) {
+	return fmt.Printf(Color(format), a...)
+}
+
+// Fprintf formats according to a format specifier and writes to w with support
+// for color codes. It returns the number of bytes written and any write error
+// encountered.
+func Fprintf(w io.Writer, format string, a ...interface{}) (n int, err error) {
+	return fmt.Fprintf(w, Color(format), a...)
+}

--- a/colorstring_test.go
+++ b/colorstring_test.go
@@ -1,6 +1,7 @@
 package colorstring
 
 import (
+	"os"
 	"testing"
 )
 
@@ -100,5 +101,48 @@ func TestColorizeColor_noReset(t *testing.T) {
 			input,
 			actual,
 			output)
+	}
+}
+
+func TestConvenienceWrappers(t *testing.T) {
+	var length int
+	printInput := "[bold]Print:\t\t[default][red]R[green]G[blue]B[cyan]C[magenta]M[yellow]Y\n"
+	printlnInput := "[bold]Println:\t[default][red]R[green]G[blue]B[cyan]C[magenta]M[yellow]Y"
+	printfInput := "[bold]Printf:\t\t[default][red]R[green]G[blue]B[cyan]C[magenta]M[yellow]Y\n"
+	fprintInput := "[bold]Fprint:\t\t[default][red]R[green]G[blue]B[cyan]C[magenta]M[yellow]Y\n"
+	fprintlnInput := "[bold]Fprintln:\t[default][red]R[green]G[blue]B[cyan]C[magenta]M[yellow]Y"
+	fprintfInput := "[bold]Fprintf:\t[default][red]R[green]G[blue]B[cyan]C[magenta]M[yellow]Y\n"
+
+	// colorstring.Print
+	length, _ = Print(printInput)
+	assertOutputLength(t, printInput, 58, length)
+
+	// colorstring.Println
+	length, _ = Println(printlnInput)
+	assertOutputLength(t, printlnInput, 59, length)
+
+	// colorstring.Printf
+	length, _ = Printf(printfInput)
+	assertOutputLength(t, printfInput, 59, length)
+
+	// colorstring.Fprint
+	length, _ = Fprint(os.Stdout, fprintInput)
+	assertOutputLength(t, fprintInput, 59, length)
+
+	// colorstring.Fprintln
+	length, _ = Fprintln(os.Stdout, fprintlnInput)
+	assertOutputLength(t, fprintlnInput, 60, length)
+
+	// colorstring.Fprintf
+	length, _ = Fprintf(os.Stdout, fprintfInput)
+	assertOutputLength(t, fprintfInput, 59, length)
+}
+
+func assertOutputLength(t *testing.T, input string, expectedLength int, actualLength int) {
+	if actualLength != expectedLength {
+		t.Errorf("Input: %#v\n\n Output length: %d\n\n Expected: %d",
+			input,
+			actualLength,
+			expectedLength)
 	}
 }


### PR DESCRIPTION
Hi Mitchell,

Thanks very much for this great little library. It works a treat.

I've created some convenience wrappers around the `fmt.*print*` methods to add support for the `colorstring` color codes. My intention is make the tool a little more DRY friendly and reduce the number of `fmt.Printf(colorstring.Color("..."), ...)` calls by simply using `colorstring.Printf("...", ...)`.

If you feel this is useful, I'd love to hear your feedback.